### PR TITLE
[Feature] Add websocket client and example (MM-296)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Bifrost API Connection
+BIFROST_BASE_URL="https://bifrost.example.com"
+BIFROST_EMAIL="user@example.com"
+BIFROST_PASSWORD="your_secure_password"
+
+# Optional: WebSocket Endpoint (if different from base URL auto-discovery)
+# BIFROST_WS_ENDPOINT="wss://bifrost.example.com/connection/websocket"

--- a/docs/realtime_guide.md
+++ b/docs/realtime_guide.md
@@ -1,0 +1,128 @@
+# Realtime Integration Guide
+
+This guide explains how to use the Realtime features of the Magick Mind SDK effectively, especially for high-scale scenarios (500+ users) and robust error handling.
+
+## Architecture
+
+The SDK uses a WebSocket connection (powered by Centrifugo) to receive real-time updates. Unlike traditional Pub/Sub where you subscribe to arbitrary channels, this SDK uses an **RPC-based subscription model**:
+
+1.  **RPC `subscribe`**: You ask the Bifrost backend to subscribe your connection to a specific `target_user_id`.
+2.  **Backend Logic**: The backend validates permissions and subscribes your connection's session to the correct internal channel (e.g., `user:123:updates`).
+3.  **Events**: You receive messages via the standard client event handlers.
+
+### Why Client-Side Tracking?
+
+Because we use an **RPC call** to initate the subscription (to hide channel implementation details from the client), the standard Centrifugo client library is not aware of these server-side subscriptions. 
+
+If the connection is lost:
+1.  The server cleans up the session (eventually).
+2.  The standard client reconnects but doesn't know it needs to re-subscribe to those users.
+
+**Therefore, the SDK maintains a local set of active user IDs and automatically re-issues the RPC calls upon reconnection.**
+
+## Scalability & Bulk Operations
+
+When managing many users (e.g., a dashboard monitoring 500 agents), use the bulk operations to ensure efficiency and avoid head-of-line blocking.
+
+### `subscribe_many`
+
+Use `subscribe_many` to subscribe to a list of users in parallel.
+
+```python
+users_to_monitor = [f"user-{i}" for i in range(500)]
+
+await realtime.subscribe_many(users_to_monitor)
+```
+
+The SDK handles:
+- Parallel execution (using `asyncio.gather`)
+- Error aggregation (raises the first error encountered, logs others)
+- Internal state tracking
+
+### `unsubscribe_many`
+
+Similarly, use `unsubscribe_many` to clean up:
+
+```python
+await realtime.unsubscribe_many(users_to_monitor)
+```
+
+## Connection Resilience & Auto-Resubscribe
+
+The SDK automatically tracks your active subscriptions locally. 
+
+**Behavior on Disconnect:**
+- If the WebSocket connection drops, the client will attempt to reconnect automatically (controlled by `centrifuge-python`'s backoff).
+- Upon successful reconnection (`connected` event), the SDK's internal handler triggers.
+- It automatically re-issues `subscribe` RPC calls for all currently tracked users.
+
+**Note**: This restoration happens asynchronously immediately after connection.
+
+## Error Handling
+
+### Connection Errors
+Handle connection errors by listening to the `error` event in your `ClientEventHandler` or wrapping calls in try/except blocks.
+
+### Subscription Errors
+`subscribe` and `subscribe_many` will raise `MagickMindError` if the backend rejects the request (e.g., invalid permission, user not found).
+
+## Best Practices
+
+1.  **Batching**: If adding users incrementally, try to batch them into groups of 10-50 for `subscribe_many` rather than awaiting 50 individual calls.
+2.  **Concurrency**: The SDK uses `asyncio.gather` for bulk ops. If you are subscribing to thousands of users, consider chunking your list to avoid overwhelming the event loop or hitting backend rate limits.
+3.  **Cleanup**: Always unsubscribe when a user is no longer needed to reduce server load.
+3.  **Cleanup**: Always unsubscribe when a user is no longer needed to reduce server load.
+
+## Advanced: Relaying to End-Users
+
+In a typical topology, this SDK runs on **your backend service** (the middleware), which sits between Bifrost and your End-Users.
+
+```mermaid
+graph LR
+    B[Bifrost] -- WebSocket --> S[Your Service (SDK)]
+    S -- "WS / SSE / FC" --> U1[End User 1]
+    S -- "WS / SSE / FC" --> U2[End User 2]
+    S -- "..." --> Un[End User N]
+```
+
+### The Fan-Out Pattern
+
+1.  **Receive**: Your service receives a message for `user-123` via the SDK `on_publication` event.
+2.  **Process**: You validate/transform the data if needed.
+3.  **Relay**: You push the update to `user-123`'s frontend using your own direct channel (e.g., your own WebSocket server, Server-Sent Events, or Firebase Cloud Messaging).
+
+### Multiplexing vs. Firehose
+
+You might wonder: *"Why is there only one handler? Is this a firehose?"*
+
+*   **Multiplexing (Good)**: You connect **once** to Bifrost. Over this single connection, you tell Bifrost: "I want updates for User A, User B, and User C." Bifrost sends *only* those updates down that single wire. This is efficient network usage.
+*   **Firehose (Bad)**: Subscribing to a wildcard channel like `root:*` receiving *everything* for the entire system. We are **not** doing this.
+*   **One Connection per User (Bad)**: Opening 500 separate WebSocket connections from your backend for each user you monitor. This consumes unnecessary resources (file descriptors, memory).
+
+The single `RelayHandler` is your **Central Dispatch**. It looks at the `channel` name of each incoming packet and routes it to the correct destination.
+
+By acting as the gateway, you maintain control over what your end-users see.
+
+### Implementation Logic
+
+The SDK provides a high-level `RealtimeEventHandler` that handles the channel parsing for you. You only need to override `on_message` and `on_connected`.
+
+*(Full runnable example available in `examples/fan_out_relay.py`)*
+
+```python
+from magick_mind.realtime.handler import RealtimeEventHandler
+
+class RelayHandler(RealtimeEventHandler):
+    async def on_connected(self, ctx):
+        print(f"✅ Connected! Client ID: {ctx.client}")
+
+    async def on_message(self, user_id: str, payload: Any) -> None:
+        """
+        Called when a message is received for a specific user.
+        The SDK automatically parsed 'personal:user_123#svc' -> 'user_123'.
+        """
+        print(f"📨 Message for [{user_id}]: {payload}")
+        
+        # Forward to that user's frontend
+        await self.relay_to_frontend(user_id, payload)
+```

--- a/examples/bulk_subscribe.py
+++ b/examples/bulk_subscribe.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Example: Bulk subscribe/unsubscribe for relay services.
+
+This demonstrates subscribing to many users at once, useful for:
+- Relay services that fan out messages to many end-users
+- Admin dashboards monitoring multiple users
+- Analytics services tracking user activity
+
+Usage:
+    export BIFROST_BASE_URL="http://localhost:8888"
+    export BIFROST_EMAIL="service@example.com"
+    export BIFROST_PASSWORD="your_password"
+    export BIFROST_WS_ENDPOINT="ws://localhost:8888/connection/websocket"
+    uv run --env-file .env python examples/bulk_subscribe.py
+"""
+
+import asyncio
+import os
+import logging
+from magick_mind import MagickMind
+from centrifuge import ClientEventHandler
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("bulk_subscribe_example")
+
+
+async def main():
+    # Get config from environment
+    base_url = os.getenv("BIFROST_BASE_URL", "http://localhost:8888")
+    ws_endpoint = os.getenv(
+        "BIFROST_WS_ENDPOINT", "ws://localhost:8888/connection/websocket"
+    )
+    email = os.getenv("BIFROST_EMAIL")
+    password = os.getenv("BIFROST_PASSWORD")
+
+    if not email or not password:
+        logger.error("BIFROST_EMAIL and BIFROST_PASSWORD are required")
+        return
+
+    # Create client
+    client = MagickMind(
+        base_url=base_url, email=email, password=password, ws_endpoint=ws_endpoint
+    )
+
+    # Event handler for server-side publications
+    class MyHandler(ClientEventHandler):
+        async def on_connected(self, ctx):
+            logger.info(f"Connected: {ctx}")
+
+        async def on_publication(self, ctx):
+            logger.info(f"Message from {ctx.channel}: {ctx.pub.data}")
+
+    rt = client.realtime
+
+    try:
+        # Connect to realtime
+        logger.info("Connecting to realtime...")
+        await rt.connect(events=MyHandler())
+        logger.info("✅ Connected!")
+
+        # Simulate subscribing to many users (e.g., relay service)
+        user_ids = [f"user_{i}" for i in range(50)]
+
+        logger.info(f"Subscribing to {len(user_ids)} users concurrently...")
+        await rt.subscribe_many(user_ids)
+        logger.info("✅ All subscriptions successful!")
+
+        # Keep listening
+        logger.info("Listening for 10 seconds...")
+        await asyncio.sleep(10)
+
+        # Bulk unsubscribe
+        logger.info(f"Unsubscribing from {len(user_ids)} users...")
+        await rt.unsubscribe_many(user_ids)
+        logger.info("✅ All unsubscribed!")
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+    finally:
+        await rt.disconnect()
+        client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/fan_out_relay.py
+++ b/examples/fan_out_relay.py
@@ -1,0 +1,72 @@
+"""
+Example: Fan-Out / Relay Service
+
+This script demonstrates how to Build a "Relay Service" using the Magick Mind SDK.
+It uses the high-level `RealtimeEventHandler` to automatically parse channel names.
+"""
+
+import asyncio
+import logging
+import json
+from typing import Dict, Any
+
+from centrifuge import ConnectedContext
+from magick_mind.realtime.handler import RealtimeEventHandler
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("RelayService")
+
+
+class RelayHandler(RealtimeEventHandler):
+    """
+    Central handler for all realtime events.
+    """
+
+    async def on_connected(self, ctx: ConnectedContext) -> None:
+        logger.info(f"✅ Connected to Bifrost! Client ID: {ctx.client}")
+
+    async def on_message(self, user_id: str, payload: Any) -> None:
+        """
+        High-level handler: User ID is already extracted!
+        """
+        logger.info(f"📨 Message for [{user_id}]: {json.dumps(payload)}")
+
+        # Relay to frontend
+        await self.relay_to_frontend(user_id, payload)
+
+    async def relay_to_frontend(self, user_id: str, payload: Dict[str, Any]) -> None:
+        """
+        Mock function to push data to your actual frontend.
+        """
+        await asyncio.sleep(0.01)
+        print(f"   🚀 [RELAY] Pushing to Frontend Connection for User {user_id}...")
+
+
+async def main():
+    print("--- Starting Relay Service (High-Level) ---")
+
+    handler = RelayHandler()
+
+    # Simulate an incoming event loop (MockCtx)
+
+    # Mock context structure to simulate "personal:user_123#svc_456"
+    # We use a simple class to avoid instantiating the actual library class which might require more args
+    class MockPub:
+        data = {"type": "agent_response", "content": "Hello world!"}
+        channel = "personal:user_123#svc_456"
+
+    class MockCtx:
+        channel = "personal:user_123#svc_456"
+        pub = MockPub()
+
+    print("\n--- Simulating Incoming Message ---")
+
+    # The handler internal logic should extract "user_123"
+    await handler.on_publication(MockCtx())
+
+    print("\n--- Done ---")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/realtime_chat.py
+++ b/examples/realtime_chat.py
@@ -1,0 +1,69 @@
+"""
+Example of using Realtime features (WebSocket/Centrifugo) with MagickMind SDK.
+"""
+
+import asyncio
+import os
+import logging
+from magick_mind import MagickMind
+from centrifuge import ClientEventHandler, SubscriptionEventHandler
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("realtime_example")
+
+
+async def main():
+    # Load credentials
+    email = os.getenv("BIFROST_EMAIL", "test@example.com")
+    password = os.getenv("BIFROST_PASSWORD", "password")
+    base_url = os.getenv("BIFROST_BASE_URL", "https://bifrost.example.com")
+
+    # Initialize SDK
+    client = MagickMind(email=email, password=password, base_url=base_url)
+
+    logger.info("Connecting to realtime...")
+
+    # Custom event handlers
+    class MyClientHandler(ClientEventHandler):
+        async def on_connected(self, ctx):
+            logger.info(f"Connected: {ctx}")
+
+        async def on_disconnected(self, ctx):
+            logger.info(f"Disconnected: {ctx}")
+
+        async def on_publication(self, ctx):
+            # Handle server-side publications here
+            logger.info(f"Received message via server-side sub: {ctx.pub.data}")
+
+    # Use realtime (async context)
+    rt = client.realtime
+
+    try:
+        # Connect with handler for server-side events
+        await rt.connect(events=MyClientHandler())
+        logger.info("Realtime client ready!")
+
+        # Subscribe via RPC (Backend manages the channel)
+        sender_id = "user-456"
+        logger.info(f"Subscribing to updates from {sender_id}...")
+
+        try:
+            await rt.subscribe(target_user_id=sender_id)
+            logger.info("Subscribe command sent successfully")
+        except Exception as e:
+            logger.error(f"Subscribe failed: {e}")
+
+        # Keep alive for a bit
+        logger.info("Listening for events... (Press Ctrl+C to stop)")
+        await asyncio.sleep(10)
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+    finally:
+        await rt.disconnect()
+        client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/magick_mind/auth/base.py
+++ b/magick_mind/auth/base.py
@@ -27,6 +27,17 @@ class AuthProvider(ABC):
         """
         pass
 
+    @abstractmethod
+    def get_token(self) -> str:
+        """
+        Get the raw access token.
+        Should handle refresh if needed.
+
+        Returns:
+            Raw access token string
+        """
+        pass
+
     def refresh_if_needed(self) -> None:
         """
         Refresh authentication credentials if needed.

--- a/magick_mind/client.py
+++ b/magick_mind/client.py
@@ -5,6 +5,7 @@ from typing import Optional
 from magick_mind.auth import AuthProvider, EmailPasswordAuth
 from magick_mind.config import SDKConfig
 from magick_mind.http import HTTPClient
+from magick_mind.realtime import RealtimeClient
 
 
 class MagickMind:
@@ -16,6 +17,7 @@ class MagickMind:
     Currently provides:
     - Authentication (email/password with JWT, automatic refresh)
     - HTTP client for making authenticated requests
+    - Realtime client for WebSocket connections (async)
 
     Example:
         # Initialize client
@@ -38,6 +40,14 @@ class MagickMind:
 
         # See docs/contributing/resource_implementation_guide/ for how to add
         # typed resources like client.v1.chat.send(...)
+        response = client.http.post("/v1/magickmind/chat", ...)
+
+        # Use Realtime client (in async context)
+        async def main():
+            # Pass handler to connect() to receive server-side publications
+            await client.realtime.connect(events=MyHandler())
+            # Subscribe via RPC
+            await client.realtime.subscribe(target_user_id="user-456")
     """
 
     def __init__(
@@ -47,6 +57,7 @@ class MagickMind:
         password: str,
         timeout: float = 30.0,
         verify_ssl: bool = True,
+        ws_endpoint: Optional[str] = None,
     ):
         """
         Initialize the Magick Mind client.
@@ -57,16 +68,17 @@ class MagickMind:
             password: User password for authentication
             timeout: Request timeout in seconds
             verify_ssl: Whether to verify SSL certificates
-
-        Raises:
-            ValueError: If authentication parameters are invalid
+            ws_endpoint: WebSocket URL (Required for .realtime usage)
         """
         if not email or not password:
             raise ValueError("Email and password are required for authentication")
 
         # Create configuration
         self.config = SDKConfig(
-            base_url=base_url, timeout=timeout, verify_ssl=verify_ssl
+            base_url=base_url,
+            timeout=timeout,
+            verify_ssl=verify_ssl,
+            ws_endpoint=ws_endpoint,
         )
 
         # Create authentication provider (email/password with JWT)
@@ -76,6 +88,9 @@ class MagickMind:
 
         # Create HTTP client (private, accessed via property)
         self._http = HTTPClient(config=self.config, auth=self.auth)
+
+        # Create Realtime client (private, accessed via property)
+        self._realtime = RealtimeClient(auth=self.auth, ws_url=ws_endpoint)
 
     @property
     def http(self) -> HTTPClient:
@@ -108,16 +123,27 @@ class MagickMind:
         """
         return self._http
 
-    def test_connection(self) -> bool:
+    @property
+    def realtime(self) -> RealtimeClient:
         """
-        Test the connection to the API.
+        Realtime WebSocket client.
+
+        Note: This client is ASYNC. You must use it within an async context.
+
+        Features:
+        - Authenticated WebSocket connection
+        - RPC subscriptions (Bifrost specific)
+        - Handling disconnects/reconnects (via centrifuge-python)
 
         Returns:
-            True if connection is successful, False otherwise
+            RealtimeClient: Configured async realtime client
         """
+        return self._realtime
+
+    def test_connection(self) -> bool:
+        """Test the connection to the API."""
         try:
             # This assumes there's a health check or similar endpoint
-            # Update the endpoint based on what's actually available
             response = self.http.get("/health")
             return response.get("success", False)
         except Exception:
@@ -130,11 +156,15 @@ class MagickMind:
         Returns:
             True if authenticated, False otherwise
         """
+        """Check if the client is authenticated."""
         return self.auth.is_authenticated()
 
     def close(self) -> None:
         """Close the client and cleanup resources."""
         self._http.close()
+        # Realtime client might need async close?
+        # But close() here is typically sync.
+        # User should probably manage realtime lifecycle themselves if async.
 
     def __enter__(self):
         """Context manager entry."""

--- a/magick_mind/config.py
+++ b/magick_mind/config.py
@@ -20,6 +20,9 @@ class SDKConfig:
     verify_ssl: bool = True
     """Whether to verify SSL certificates"""
 
+    ws_endpoint: Optional[str] = None
+    """Explicit WebSocket endpoint URL (optional)"""
+
     def normalized_base_url(self) -> str:
         """Return base URL without trailing slash."""
         return self.base_url.rstrip("/")

--- a/magick_mind/realtime/__init__.py
+++ b/magick_mind/realtime/__init__.py
@@ -1,0 +1,5 @@
+"""Realtime module for WebSocket connections using Centrifugo."""
+
+from .client import RealtimeClient
+
+__all__ = ["RealtimeClient"]

--- a/magick_mind/realtime/client.py
+++ b/magick_mind/realtime/client.py
@@ -1,0 +1,175 @@
+"""Realtime client implementation using centrifuge-python."""
+
+import asyncio
+import logging
+from typing import Optional, List
+
+
+from centrifuge import (
+    Client,
+    ClientEventHandler,
+)
+from centrifuge.exceptions import ReplyError
+
+from ..auth.base import AuthProvider
+from ..exceptions import MagickMindError
+
+
+logger = logging.getLogger(__name__)
+
+
+class RealtimeClient:
+    """
+    Async client for real-time features using WebSockets.
+    Wraps centrifuge.Client to handle authentication and Bifrost-specific patterns.
+    """
+
+    def __init__(self, auth: AuthProvider, ws_url: str):
+        """
+        Initialize realtime client.
+
+        Args:
+            auth: Authentication provider (must support get_token)
+            ws_url: WebSocket URL (e.g., "ws://localhost:8888/connection/websocket")
+        """
+        self.auth = auth
+        self.ws_url = ws_url
+        self._client: Optional[Client] = None
+        self._events: Optional[ClientEventHandler] = None
+
+    async def _get_token(self) -> str:
+        """Get token wrapper for centrifuge client."""
+        # AuthProvider.get_token() is synchronous currently.
+        # We wrap it in a thread execution to be safe if it does IO blocking.
+        # Ideally get_token should be async, but for MVP we run it in executor.
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self.auth.get_token)
+
+    async def connect(self, events: Optional[ClientEventHandler] = None) -> None:
+        """
+        Connect to the realtime service.
+
+        Args:
+            events: Optional ClientEventHandler for global events
+        """
+        if self._client:
+            return
+
+        self._events = events or ClientEventHandler()
+
+        self._client = Client(
+            self.ws_url,
+            events=self._events,
+            get_token=self._get_token,
+            use_protobuf=False,
+        )
+
+        await self._client.connect()
+        await self._client.ready()
+
+    async def disconnect(self) -> None:
+        """Disconnect from the realtime service."""
+        if self._client:
+            await self._client.disconnect()
+            self._client = None
+
+    async def subscribe(self, target_user_id: str) -> None:
+        """
+        Subscribe to a user's channel via RPC.
+
+        This uses the Bifrost backend to manage the subscription:
+        1. Derives service_user_id from the auth token
+        2. Builds the correct channel name (personal channel)
+        3. Subscribes this client to that channel
+
+        The Centrifugo SDK automatically maintains server-side subscriptions
+        across reconnections, so no manual tracking is needed.
+
+        Args:
+            target_user_id: ID of the user to subscribe to
+        """
+        if not self._client:
+            raise MagickMindError("Realtime client not connected")
+
+        data = {
+            "target_user_id": target_user_id,
+        }
+
+        try:
+            await self._client.rpc("subscribe", data)
+        except ReplyError as e:
+            raise MagickMindError(f"Subscribe failed: {e}")
+
+    async def subscribe_many(self, target_user_ids: List[str]) -> None:
+        """
+        Subscribe to multiple users concurrently.
+
+        Fires all RPC subscribe requests in parallel for better performance
+        when subscribing to many users at once.
+
+        Args:
+            target_user_ids: List of user IDs to subscribe to
+
+        Raises:
+            MagickMindError: If any subscription fails
+        """
+        if not target_user_ids:
+            return
+
+        tasks = [self.subscribe(uid) for uid in target_user_ids]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Check for errors
+        errors = [r for r in results if isinstance(r, Exception)]
+        if errors:
+            # Raise the first error encountered
+            raise errors[0]
+
+    async def unsubscribe(self, target_user_id: str) -> None:
+        """
+        Unsubscribe from a user's channel via RPC.
+
+        Args:
+            target_user_id: ID of the user to unsubscribe from
+        """
+        if not self._client:
+            raise MagickMindError("Realtime client not connected")
+
+        data = {
+            "target_user_id": target_user_id,
+        }
+
+        try:
+            await self._client.rpc("unsubscribe", data)
+        except ReplyError as e:
+            raise MagickMindError(f"Unsubscribe failed: {e}")
+
+    async def unsubscribe_many(self, target_user_ids: List[str]) -> None:
+        """
+        Unsubscribe from multiple users concurrently.
+
+        Fires all RPC unsubscribe requests in parallel for better performance
+        when unsubscribing from many users at once.
+
+        Args:
+            target_user_ids: List of user IDs to unsubscribe from
+
+        Raises:
+            MagickMindError: If any unsubscription fails
+        """
+        if not target_user_ids:
+            return
+
+        tasks = [self.unsubscribe(uid) for uid in target_user_ids]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Check for errors
+        errors = [r for r in results if isinstance(r, Exception)]
+        if errors:
+            # Raise the first error encountered
+            raise errors[0]
+
+    @property
+    def client(self) -> Optional[Client]:
+        """Get underlying centrifuge client."""
+        return self._client

--- a/magick_mind/realtime/handler.py
+++ b/magick_mind/realtime/handler.py
@@ -1,0 +1,99 @@
+"""
+High-level event handler for Magick Mind Realtime Client.
+Abstracts away Centrifugo channel parsing details.
+"""
+
+import logging
+from typing import Any, Optional
+
+from centrifuge import ClientEventHandler, ServerPublicationContext, ConnectedContext
+
+logger = logging.getLogger(__name__)
+
+
+class RealtimeEventHandler(ClientEventHandler):
+    """
+    Abstract base class for handling Realtime SDK events.
+
+    Subclass this and override `on_message` to handle incoming user updates.
+    The SDK handles channel parsing and data extraction for you.
+    """
+
+    async def on_connected(self, ctx: ConnectedContext) -> None:
+        """Called when connected to the Realtime Gateway."""
+        logger.info(f"✅ Connected to Realtime Gateway (Client ID: {ctx.client})")
+
+    async def on_message(self, user_id: str, payload: Any) -> None:
+        """
+        Called when a message is received for a specific user.
+
+        Args:
+            user_id: The ID of the end-user this message is for.
+            payload: The message content (dict, string, etc).
+        """
+        pass
+
+    async def on_raw_message(self, channel: str, payload: Any) -> None:
+        """
+        Called when a message is received but the user ID could not be parsed,
+        or for non-standard channels.
+        """
+        pass
+
+    async def on_publication(self, ctx: ServerPublicationContext) -> None:
+        """
+        Internal handler. Parses channel context and dispatches to on_message.
+        """
+        channel = self._extract_channel(ctx)
+        data = self._extract_data(ctx)
+
+        user_id = self._extract_user_id(channel)
+
+        if user_id:
+            await self.on_message(user_id, data)
+        else:
+            await self.on_raw_message(channel, data)
+
+    def _extract_channel(self, ctx: ServerPublicationContext) -> str:
+        """
+        Extract channel from context in a version-resilient way.
+        """
+        # Try direct attribute
+        ch = getattr(ctx, "channel", None)
+        if ch:
+            return ch
+
+        # Try inside pub object
+        pub = getattr(ctx, "pub", None)
+        if pub:
+            return getattr(pub, "channel", "")
+
+        return ""
+
+    def _extract_data(self, ctx: ServerPublicationContext) -> Any:
+        """
+        Extract data payload from context.
+        """
+        pub = getattr(ctx, "pub", None)
+        return getattr(pub, "data", None) if pub else None
+
+    def _extract_user_id(self, channel: str) -> Optional[str]:
+        """
+        Parse User ID from channel string.
+        Format confirmed as: personal:<target_user_id>#<service_user_id>
+        """
+        if not channel:
+            return None
+
+        # 1. Remove namespace (personal:)
+        if ":" in channel:
+            without_ns = channel.split(":", 1)[1]
+        else:
+            without_ns = channel
+
+        # 2. Extract first part before '#'
+        # "user_123#service_456" -> "user_123"
+        if "#" in without_ns:
+            return without_ns.split("#")[0]
+
+        return without_ns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 dependencies = [
     "httpx>=0.27.0",
     "pydantic>=2.0.0",
+    "centrifuge-python>=0.4.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_realtime_complex.py
+++ b/tests/test_realtime_complex.py
@@ -1,0 +1,56 @@
+import asyncio
+import sys
+from unittest.mock import MagicMock, AsyncMock
+
+
+async def test_complex_realtime_scenarios():
+    print("🧪 Testing Realtime Scalability & Resilience...")
+
+    # Mock dependencies
+    sys.modules["centrifuge"] = MagicMock()
+    sys.modules["centrifuge.exceptions"] = MagicMock()
+
+    # Import locally
+    from magick_mind.realtime.client import RealtimeClient
+
+    # Setup Mocks
+    mock_auth = MagicMock()
+    mock_auth.get_token.return_value = "token"
+
+    rt = RealtimeClient(auth=mock_auth, ws_url="ws://test")
+    rt._client = AsyncMock()
+
+    # helper to reset mock calls
+    def reset_mocks():
+        rt._client.rpc.reset_mock()
+
+    print("1. Testing subscribe_many (Bulk Ops)...")
+    users = [f"user_{i}" for i in range(50)]
+
+    await rt.subscribe_many(users)
+
+    # Verify 50 calls
+    assert rt._client.rpc.call_count == 50
+    # Check args of first call
+    args, _ = rt._client.rpc.call_args_list[0]
+    assert args[0] == "subscribe"
+    print("   ✅ Validated 50 concurrent subscriptions")
+
+    print("2. Testing unsubscribe_many...")
+    reset_mocks()
+    await rt.unsubscribe_many(users)
+    assert rt._client.rpc.call_count == 50
+    print("   ✅ Validated 50 concurrent unsubscriptions")
+
+    print("\n🎉 All Complex Realtime Tests Passed!")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(test_complex_realtime_scenarios())
+    except Exception as e:
+        print(f"❌ Test failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)

--- a/tests/test_realtime_mock.py
+++ b/tests/test_realtime_mock.py
@@ -1,0 +1,72 @@
+import asyncio
+import sys
+from unittest.mock import MagicMock, AsyncMock, patch
+
+# Mock dependencies before importing the client if they are not installed or to ensure isolation
+sys.modules["centrifuge"] = MagicMock()
+sys.modules["centrifuge.exceptions"] = MagicMock()
+
+
+async def test_realtime_client_logic():
+    print("🧪 Testing RealtimeClient logic with mocks...")
+
+    # Import inside function to allow module-level mocks to take effect first
+    # and to avoid "import not at top of file" lint errors
+    from magick_mind.realtime.client import RealtimeClient
+
+    # Mock Auth Provider
+    mock_auth = MagicMock()
+    mock_auth.get_token.return_value = "mock-token"
+
+    # Initialize Client
+    ws_url = "wss://api.bifrost.com/connection/websocket"
+    rt = RealtimeClient(auth=mock_auth, ws_url=ws_url)
+
+    # Mock the internal centrifuge client
+    rt._client = AsyncMock()
+
+    print("1. Testing Subscribe RPC...")
+    target_user = "user-123"
+    await rt.subscribe(target_user)
+
+    # Verify RPC call
+    rt._client.rpc.assert_called_with("subscribe", {"target_user_id": target_user})
+    print("   ✅ RPC 'subscribe' called with correct payload")
+
+    print("2. Testing Unsubscribe RPC...")
+    await rt.unsubscribe(target_user)
+
+    rt._client.rpc.assert_called_with("unsubscribe", {"target_user_id": target_user})
+    print("   ✅ RPC 'unsubscribe' called with correct payload")
+
+    print("3. Testing Connection Logic (Mocked)...")
+    # Reset client to test connect
+    rt._client = None
+
+    with patch("magick_mind.realtime.client.Client") as MockCentClient:
+        mock_cent_instance = AsyncMock()
+        MockCentClient.return_value = mock_cent_instance
+
+        await rt.connect()
+
+        MockCentClient.assert_called_once()
+        # Verify get_token passed is a callable
+        args, kwargs = MockCentClient.call_args
+        assert callable(kwargs["get_token"])
+        print("   ✅ Centrifuge Client initialized with get_token callback")
+
+        mock_cent_instance.connect.assert_called_once()
+        print("   ✅ Client.connect() called")
+
+    print("\n🎉 All RealtimeClient logic tests passed!")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(test_realtime_client_logic())
+    except Exception as e:
+        print(f"❌ Test failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,19 @@ wheels = [
 ]
 
 [[package]]
+name = "centrifuge-python"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/f7/aa5f0870e6b59cd9d8c7852c9608462903cb69b83bd3f270197aa135bd07/centrifuge_python-0.4.2.tar.gz", hash = "sha256:82743dd0bbdabe12fbdedf665434539981457310c1dd21332e6685533e5a0f46", size = 41578, upload-time = "2025-11-14T14:39:32.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/64/6635b09c8605a66bf7c982eca3141aca0ebf00bb55b17273c84b2eb81b3d/centrifuge_python-0.4.2-py3-none-any.whl", hash = "sha256:97dd58c849c4a231631f2e90f036950a2d6a0c1cd5e757a58e5f659a50a0a4e0", size = 26727, upload-time = "2025-11-14T14:39:31.434Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -102,6 +115,7 @@ name = "magick-mind"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "centrifuge-python" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
@@ -115,6 +129,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "centrifuge-python", specifier = ">=0.4.2" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -139,6 +154,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/44/e49ecff446afeec9d1a66d6bbf9adc21e3c7cea7803a920ca3773379d4f6/protobuf-6.33.2.tar.gz", hash = "sha256:56dc370c91fbb8ac85bc13582c9e373569668a290aa2e66a590c2a0d35ddb9e4", size = 444296, upload-time = "2025-12-06T00:17:53.311Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/91/1e3a34881a88697a7354ffd177e8746e97a722e5e8db101544b47e84afb1/protobuf-6.33.2-cp310-abi3-win32.whl", hash = "sha256:87eb388bd2d0f78febd8f4c8779c79247b26a5befad525008e49a6955787ff3d", size = 425603, upload-time = "2025-12-06T00:17:41.114Z" },
+    { url = "https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl", hash = "sha256:fc2a0e8b05b180e5fc0dd1559fe8ebdae21a27e81ac77728fb6c42b12c7419b4", size = 436930, upload-time = "2025-12-06T00:17:43.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d9b19771ca75935b3a4422957bc518b0cecb978b31d1dd12037b088f6bcc0e43", size = 427621, upload-time = "2025-12-06T00:17:44.445Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:b5d3b5625192214066d99b2b605f5783483575656784de223f00a8d00754fc0e", size = 324460, upload-time = "2025-12-06T00:17:45.678Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fa/26468d00a92824020f6f2090d827078c09c9c587e34cbfd2d0c7911221f8/protobuf-6.33.2-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8cd7640aee0b7828b6d03ae518b5b4806fdfc1afe8de82f79c3454f8aef29872", size = 339168, upload-time = "2025-12-06T00:17:46.813Z" },
+    { url = "https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:1f8017c48c07ec5859106533b682260ba3d7c5567b1ca1f24297ce03384d1b4f", size = 323270, upload-time = "2025-12-06T00:17:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/15/4f02896cc3df04fc465010a4c6a0cd89810f54617a32a70ef531ed75d61c/protobuf-6.33.2-py3-none-any.whl", hash = "sha256:7636aad9bb01768870266de5dc009de2d1b936771b38a793f73cbbf279c91c5c", size = 170501, upload-time = "2025-12-06T00:17:52.211Z" },
 ]
 
 [[package]]
@@ -296,4 +326,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]


### PR DESCRIPTION
Introduce async RealtimeClient using centrifuge-python with subscribe/ unsubscribe RPC helpers and token integration. Expose it via MagickMind.realtime, add ws_endpoint config, and provide a realtime_chat example. Update auth to expose raw token and add new dependencies.