### PR TITLE
feat(sdk): add corpus artifact management methods (MM-642)

### DIFF
--- a/docs/resources/corpus.md
+++ b/docs/resources/corpus.md
@@ -109,7 +109,9 @@ print(response.message)
 
 ## Working with Artifacts
 
-Corpus contain **artifacts** (uploaded files). Here's the complete workflow:
+Corpus contain **artifacts** (uploaded files). The SDK provides dedicated methods for managing artifacts within a corpus — no need to manually read-modify-update the artifact list.
+
+**Supported formats:** text-based files (`text/*`, JSON, XML) and PDF. Other formats will be rejected during ingestion.
 
 ### 1. Upload Files to Create Artifacts
 
@@ -149,40 +151,46 @@ print(f"Uploaded artifact: {artifact_id}")
 ### 2. Add Artifacts to Corpus
 
 ```python
-# Get current corpus state
-corpus = client.v1.corpus.get("corp-123")
+# Add a single artifact (triggers ingestion automatically)
+result = client.v1.corpus.add_artifact("corp-123", artifact_id)
+print(f"Added: {result.added_count}, Failed: {result.failed_artifact_ids}")
 
-# Add new artifact while preserving existing ones
-updated_artifacts = corpus.corpus.artifact_ids + [artifact_id]
-
-# Update corpus
-client.v1.corpus.update(
-    corpus_id="corp-123",
-    name=corpus.corpus.name,
-    description=corpus.corpus.description,
-    artifact_ids=updated_artifacts
-)
+# Add multiple artifacts in batch (max 20 per call)
+result = client.v1.corpus.add_artifacts("corp-123", [
+    "art-001", "art-002", "art-003"
+])
+print(f"Added: {result.added_count}")
+if result.failed_artifact_ids:
+    print(f"Failed: {result.failed_artifact_ids}")
 ```
 
 ### 3. Remove Artifacts from Corpus
 
 ```python
-# Get current state
-corpus = client.v1.corpus.get("corp-123")
+# Remove a single artifact by ID
+client.v1.corpus.remove_artifact("corp-123", "art-old-001")
+```
 
-# Remove specific artifact
-artifact_to_remove = "art-old-001"
-updated_artifacts = [
-    aid for aid in corpus.corpus.artifact_ids 
-    if aid != artifact_to_remove
-]
+### 4. Track Ingestion Status
 
-# Update
-client.v1.corpus.update(
-    corpus_id="corp-123",
-    name=corpus.corpus.name,
-    description=corpus.corpus.description,
-    artifact_ids=updated_artifacts
+After adding artifacts, they go through an ingestion pipeline: `PENDING → PROCESSING → PROCESSED` (or `FAILED`).
+
+```python
+# Check status of a single artifact
+status = client.v1.corpus.get_artifact_status("corp-123", "art-001")
+print(f"{status.artifact_id}: {status.status}")  # e.g. "PROCESSING"
+if status.error:
+    print(f"Error: {status.error}")
+
+# List statuses for all artifacts in a corpus
+statuses = client.v1.corpus.list_artifact_statuses("corp-123")
+for s in statuses:
+    print(f"  {s.artifact_id}: {s.status} ({s.content_length or '?'} bytes)")
+
+# Filter to specific artifacts
+statuses = client.v1.corpus.list_artifact_statuses(
+    "corp-123",
+    artifact_ids=["art-001", "art-002"]
 )
 ```
 
@@ -197,30 +205,26 @@ def build_knowledge_base(name: str, description: str, file_paths: list[str]):
     """Create a corpus from local files."""
     
     # 1. Create empty corpus
-    corpus_resp = client.v1.corpus.create(
+    corpus = client.v1.corpus.create(
         name=name,
         description=description,
-        artifact_ids=[]
     )
-    corpus_id = corpus_resp.corpus.id
+    corpus_id = corpus.id
     print(f"Created corpus: {corpus_id}")
     
     # 2. Upload all files
     artifact_ids = []
     for file_path in file_paths:
-        # Get file info
         file_size = os.path.getsize(file_path)
         file_name = os.path.basename(file_path)
         content_type = guess_content_type(file_name)
         
-        # Presign
         presign = client.v1.artifact.presign(
             file_name=file_name,
             content_type=content_type,
             size_bytes=file_size
         )
         
-        # Upload to S3
         with open(file_path, "rb") as f:
             httpx.put(
                 presign.upload_url,
@@ -231,15 +235,12 @@ def build_knowledge_base(name: str, description: str, file_paths: list[str]):
         artifact_ids.append(presign.id)
         print(f"  Uploaded: {file_name}")
     
-    # 3. Associate artifacts with corpus
-    client.v1.corpus.update(
-        corpus_id=corpus_id,
-        name=name,
-        description=description,
-        artifact_ids=artifact_ids
-    )
+    # 3. Add artifacts to corpus (triggers ingestion)
+    result = client.v1.corpus.add_artifacts(corpus_id, artifact_ids)
+    print(f"✓ Added {result.added_count} files to corpus")
+    if result.failed_artifact_ids:
+        print(f"  Failed: {result.failed_artifact_ids}")
     
-    print(f"✓ Knowledge base ready with {len(artifact_ids)} files")
     return corpus_id
 
 # Usage
@@ -342,20 +343,8 @@ def add_document_to_corpus(corpus_id: str, file_path: str):
             headers=presign.required_headers
         ).raise_for_status()
     
-    # Get current corpus
-    corpus = client.v1.corpus.get(corpus_id)
-    
-    # Add to artifact list
-    updated_artifacts = corpus.corpus.artifact_ids + [presign.id]
-    
-    # Update corpus
-    client.v1.corpus.update(
-        corpus_id=corpus_id,
-        name=corpus.corpus.name,
-        description=corpus.corpus.description,
-        artifact_ids=updated_artifacts
-    )
-    
+    # Add to corpus (triggers ingestion automatically)
+    client.v1.corpus.add_artifact(corpus_id, presign.id)
     print(f"Added {file_name} to corpus {corpus_id}")
 
 # Usage
@@ -470,24 +459,19 @@ Make it clear what knowledge the corpus contains:
 
 ### 3. Manage Artifact Lifecycles
 
-Clean up outdated documents:
+Clean up outdated documents and monitor ingestion:
 
 ```python
-# Regularly review and remove outdated artifacts
-corpus = client.v1.corpus.get("corp-123")
+# Review artifact statuses
+statuses = client.v1.corpus.list_artifact_statuses("corp-123")
 
-# Filter out expired/deprecated artifacts
-updated_artifacts = [
-    aid for aid in corpus.corpus.artifact_ids
-    if not is_deprecated(aid)
-]
-
-client.v1.corpus.update(
-    corpus_id="corp-123",
-    name=corpus.corpus.name,
-    description=corpus.corpus.description,
-    artifact_ids=updated_artifacts
-)
+for s in statuses:
+    if s.status == "FAILED":
+        print(f"Removing failed artifact {s.artifact_id}: {s.error}")
+        client.v1.corpus.remove_artifact("corp-123", s.artifact_id)
+    elif is_deprecated(s.artifact_id):
+        print(f"Removing deprecated artifact {s.artifact_id}")
+        client.v1.corpus.remove_artifact("corp-123", s.artifact_id)
 ```
 
 ### 4. Consider Access Patterns
@@ -568,8 +552,71 @@ Delete a corpus.
 
 **Returns:** `DeleteCorpusResponse`
 
+---
+
+### `add_artifact()`
+
+Add a single artifact to a corpus and trigger ingestion.
+
+**Parameters:**
+- `corpus_id` (str, required): Corpus ID
+- `artifact_id` (str, required): Artifact ID to add
+
+**Returns:** `AddArtifactsResponse` (`added_count`, `failed_artifact_ids`)
+
+---
+
+### `add_artifacts()`
+
+Add multiple artifacts to a corpus in batch (max 20) and trigger ingestion.
+
+**Supported formats:** text-based (`text/*`, JSON, XML) and PDF.
+
+**Parameters:**
+- `corpus_id` (str, required): Corpus ID
+- `artifact_ids` (list[str], required): Artifact IDs to add (1-20)
+
+**Returns:** `AddArtifactsResponse` (`added_count`, `failed_artifact_ids`)
+
+---
+
+### `remove_artifact()`
+
+Remove an artifact from a corpus.
+
+**Parameters:**
+- `corpus_id` (str, required): Corpus ID
+- `artifact_id` (str, required): Artifact ID to remove
+
+**Returns:** None
+
+---
+
+### `get_artifact_status()`
+
+Get ingestion status for a single artifact in a corpus.
+
+**Parameters:**
+- `corpus_id` (str, required): Corpus ID
+- `artifact_id` (str, required): Artifact ID
+
+**Returns:** `ArtifactStatus` (`artifact_id`, `status`, `content_summary`, `content_length`, `created_at`, `updated_at`, `error`)
+
+Status values: `PENDING`, `PROCESSING`, `PROCESSED`, `FAILED`
+
+---
+
+### `list_artifact_statuses()`
+
+List ingestion statuses for artifacts in a corpus.
+
+**Parameters:**
+- `corpus_id` (str, required): Corpus ID
+- `artifact_ids` (list[str], optional): Filter to specific artifact IDs
+
+**Returns:** `list[ArtifactStatus]`
+
 ## Related Resources
 
-- [Artifact Resource Guide](file:///Users/berry/centrifugo/AGD_Magick_Mind_SDK/docs/resources/artifact.md) - Uploading and managing files
-- [Mindspace Resource Guide](file:///Users/berry/centrifugo/AGD_Magick_Mind_SDK/docs/resources/mindspace.md) - Attaching corpus to conversations
-- [Corpus Example](file:///Users/berry/centrifugo/AGD_Magick_Mind_SDK/examples/corpus_example.py) - Complete usage examples
+- [Artifact Resource Guide](./artifact.md) - Uploading and managing files
+- [Mindspace Resource Guide](./mindspace.md) - Attaching corpus to conversations

--- a/examples/resource_management.py
+++ b/examples/resource_management.py
@@ -5,6 +5,7 @@ Demonstrates CRUD operations for core resources using the Magick Mind SDK:
 - End Users: User identity management in multi-tenant architecture
 - Projects: Organize corpus and resources for agentic SaaS backends
 - Mindspaces: Central organizing concept for conversations and collaboration
+- Corpus: Knowledge base and artifact management for RAG workflows
 
 This example consolidates patterns from end_user_example.py, project_example.py,
 and mindspace_example.py into a single comprehensive resource management guide.
@@ -238,11 +239,87 @@ def main():
         print("  (No messages in this mindspace yet)")
 
     # ========================================================================
+    # PART 4: CORPUS & ARTIFACT MANAGEMENT
+    # ========================================================================
+    print("\n" + "=" * 60)
+    print("PART 4: Corpus & Artifact Management")
+    print("=" * 60)
+
+    # 1. Create a corpus
+    print("\n1. Creating a corpus...")
+    corpus = client.v1.corpus.create(
+        name="SDK Example Knowledge Base",
+        description="Documents for testing artifact management",
+    )
+    corpus_id = corpus.id
+    print(f"✓ Created corpus: {corpus_id}")
+    print(f"  Name: {corpus.name}")
+
+    # 2. Add artifacts to corpus (triggers ingestion)
+    # Note: These artifact IDs would come from prior uploads via artifact.presign()
+    print("\n2. Adding artifacts to corpus...")
+    try:
+        result = client.v1.corpus.add_artifacts(
+            corpus_id, ["artifact-001", "artifact-002"]
+        )
+        print(f"✓ Added {result.added_count} artifact(s)")
+        if result.failed_artifact_ids:
+            print(f"  Failed: {result.failed_artifact_ids}")
+    except Exception as e:
+        print(f"  Skipped (no real artifacts): {e}")
+
+    # 3. Add a single artifact
+    print("\n3. Adding a single artifact...")
+    try:
+        result = client.v1.corpus.add_artifact(corpus_id, "artifact-003")
+        print(f"✓ Added {result.added_count} artifact(s)")
+    except Exception as e:
+        print(f"  Skipped (no real artifact): {e}")
+
+    # 4. List artifact statuses
+    print("\n4. Listing artifact statuses...")
+    try:
+        statuses = client.v1.corpus.list_artifact_statuses(corpus_id)
+        print(f"✓ Found {len(statuses)} artifact status(es):")
+        for s in statuses[:5]:
+            print(f"  - {s.artifact_id}: {s.status}")
+            if s.error:
+                print(f"    Error: {s.error}")
+    except Exception as e:
+        print(f"  Skipped: {e}")
+
+    # 5. Get single artifact status
+    print("\n5. Getting single artifact status...")
+    try:
+        status = client.v1.corpus.get_artifact_status(corpus_id, "artifact-001")
+        print(f"✓ Status: {status.status}")
+        print(f"  Content length: {status.content_length}")
+        print(f"  Updated at: {status.updated_at}")
+    except Exception as e:
+        print(f"  Skipped: {e}")
+
+    # 6. Remove artifact from corpus
+    print("\n6. Removing artifact from corpus...")
+    try:
+        client.v1.corpus.remove_artifact(corpus_id, "artifact-001")
+        print("✓ Artifact removed")
+    except Exception as e:
+        print(f"  Skipped: {e}")
+
+    # ========================================================================
     # CLEANUP
     # ========================================================================
     print("\n" + "=" * 60)
     print("CLEANUP")
     print("=" * 60)
+
+    # Delete corpus
+    print(f"\n0. Deleting corpus {corpus_id}...")
+    try:
+        client.v1.corpus.delete(corpus_id)
+        print(f"✓ Deleted corpus: {corpus_id}")
+    except Exception as e:
+        print(f"✗ Failed to delete corpus: {e}")
 
     # Delete mindspace
     print(f"\n1. Deleting mindspace {mindspace_id}...")

--- a/magick_mind/models/v1/__init__.py
+++ b/magick_mind/models/v1/__init__.py
@@ -13,8 +13,12 @@ from magick_mind.models.v1.artifact import (
 )
 from magick_mind.models.v1.chat import ChatPayload, ChatSendRequest, ChatSendResponse
 from magick_mind.models.v1.corpus import (
+    AddArtifactsRequest,
+    AddArtifactsResponse,
+    ArtifactStatus,
     Corpus,
     CreateCorpusRequest,
+    ListArtifactStatusesResponse,
     ListCorpusResponse,
     UpdateCorpusRequest,
 )
@@ -70,6 +74,10 @@ __all__ = [
     "CreateCorpusRequest",
     "ListCorpusResponse",
     "UpdateCorpusRequest",
+    "AddArtifactsRequest",
+    "AddArtifactsResponse",
+    "ArtifactStatus",
+    "ListArtifactStatusesResponse",
     "ApiKey",
     "KeyResponse",
     "CreateApiKeyRequest",

--- a/magick_mind/models/v1/corpus.py
+++ b/magick_mind/models/v1/corpus.py
@@ -80,3 +80,34 @@ class DeleteCorpusResponse:
     """
 
     pass
+
+
+class AddArtifactsRequest(BaseModel):
+    """Request for adding artifacts to a corpus."""
+
+    artifact_ids: list[str] = Field(..., min_length=1, max_length=20)
+
+
+class AddArtifactsResponse(BaseModel):
+    """Response for adding artifacts to a corpus."""
+
+    added_count: int
+    failed_artifact_ids: list[str] = Field(default_factory=list)
+
+
+class ArtifactStatus(BaseModel):
+    """Status of an artifact in a corpus."""
+
+    artifact_id: str
+    status: str  # PENDING, PROCESSING, PROCESSED, FAILED
+    content_summary: Optional[str] = None
+    content_length: Optional[int] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    error: Optional[str] = None
+
+
+class ListArtifactStatusesResponse(BaseModel):
+    """Response for listing artifact statuses."""
+
+    statuses: list[ArtifactStatus]

--- a/magick_mind/resources/v1/corpus.py
+++ b/magick_mind/resources/v1/corpus.py
@@ -9,8 +9,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from magick_mind.models.v1.corpus import (
+    AddArtifactsRequest,
+    AddArtifactsResponse,
+    ArtifactStatus,
     Corpus,
     CreateCorpusRequest,
+    ListArtifactStatusesResponse,
     ListCorpusResponse,
     UpdateCorpusRequest,
 )
@@ -154,3 +158,108 @@ class CorpusResourceV1:
             httpx.HTTPStatusError: If request fails
         """
         self.http.delete(Routes.corpus(corpus_id))
+
+    def add_artifact(self, corpus_id: str, artifact_id: str) -> AddArtifactsResponse:
+        """
+        Add a single artifact to corpus and trigger ingestion.
+
+        Args:
+            corpus_id: The corpus ID
+            artifact_id: The artifact ID to add
+
+        Returns:
+            AddArtifactsResponse with result
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails
+        """
+        return self.add_artifacts(corpus_id, [artifact_id])
+
+    def add_artifacts(
+        self, corpus_id: str, artifact_ids: list[str]
+    ) -> AddArtifactsResponse:
+        """
+        Add multiple artifacts to corpus (max 20) and trigger batch ingestion.
+
+        Note: Only text-based formats (text/*, JSON, XML) and PDF are supported.
+
+        Args:
+            corpus_id: The corpus ID
+            artifact_ids: List of artifact IDs to add (max 20)
+
+        Returns:
+            AddArtifactsResponse with result
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails
+        """
+        payload = AddArtifactsRequest(artifact_ids=artifact_ids)
+
+        resp = self.http.post(
+            Routes.corpus_artifacts(corpus_id), json=payload.model_dump()
+        )
+        resp.raise_for_status()
+
+        return AddArtifactsResponse(**resp.json())
+
+    def remove_artifact(self, corpus_id: str, artifact_id: str) -> None:
+        """
+        Remove artifact from corpus.
+
+        Args:
+            corpus_id: The corpus ID
+            artifact_id: The artifact ID to remove
+
+        Returns:
+            None
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails
+        """
+        resp = self.http.delete(Routes.corpus_artifact(corpus_id, artifact_id))
+        resp.raise_for_status()
+
+    def get_artifact_status(self, corpus_id: str, artifact_id: str) -> ArtifactStatus:
+        """
+        Get ingestion status for a single artifact.
+
+        Args:
+            corpus_id: The corpus ID
+            artifact_id: The artifact ID
+
+        Returns:
+            ArtifactStatus object
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails
+        """
+        resp = self.http.get(Routes.corpus_artifact_status(corpus_id, artifact_id))
+        resp.raise_for_status()
+
+        return ArtifactStatus(**resp.json())
+
+    def list_artifact_statuses(
+        self, corpus_id: str, artifact_ids: Optional[list[str]] = None
+    ) -> list[ArtifactStatus]:
+        """
+        List ingestion statuses for artifacts in corpus.
+
+        Args:
+            corpus_id: The corpus ID
+            artifact_ids: Optional list of specific artifact IDs to filter
+
+        Returns:
+            List of ArtifactStatus objects
+
+        Raises:
+            httpx.HTTPStatusError: If the request fails
+        """
+        params = {}
+        if artifact_ids:
+            params["artifact_ids"] = artifact_ids
+
+        resp = self.http.get(Routes.corpus_artifacts_status(corpus_id), params=params)
+        resp.raise_for_status()
+
+        data = ListArtifactStatusesResponse(**resp.json())
+        return data.statuses

--- a/magick_mind/routes.py
+++ b/magick_mind/routes.py
@@ -59,6 +59,26 @@ class Routes:
         """Get path for corpus artifact finalization."""
         return f"/v1/corpus/{corpus_id}/artifacts/finalize"
 
+    @staticmethod
+    def corpus_artifacts(corpus_id: str) -> str:
+        """Get path for corpus artifacts management."""
+        return f"/v1/corpus/{corpus_id}/artifacts"
+
+    @staticmethod
+    def corpus_artifact(corpus_id: str, artifact_id: str) -> str:
+        """Get path for a specific corpus artifact."""
+        return f"/v1/corpus/{corpus_id}/artifacts/{artifact_id}"
+
+    @staticmethod
+    def corpus_artifact_status(corpus_id: str, artifact_id: str) -> str:
+        """Get path for corpus artifact status."""
+        return f"/v1/corpus/{corpus_id}/artifacts/{artifact_id}/status"
+
+    @staticmethod
+    def corpus_artifacts_status(corpus_id: str) -> str:
+        """Get path for listing corpus artifacts status."""
+        return f"/v1/corpus/{corpus_id}/artifacts/status"
+
     # Artifact endpoints
     ARTIFACTS = "/v1/artifacts"
     ARTIFACTS_PRESIGN = "/v1/artifacts/presign"


### PR DESCRIPTION
Add dedicated methods for managing artifacts within a corpus:
- add_artifact/add_artifacts (batch, max 20) with ingestion trigger
- remove_artifact, get_artifact_status, list_artifact_statuses
- Supporting models, routes, docs, and example updates