### PR TITLE
fix(examples): use status.error for failed ingestion message

### DIFF
--- a/examples/corpus_ingest.py
+++ b/examples/corpus_ingest.py
@@ -173,7 +173,7 @@ async def main() -> None:
                     print(f"   Ingestion complete ({elapsed:.0f}s)\n")
                     break
                 if status.status.upper() == "FAILED":
-                    print(f"   Ingestion FAILED: {status.content_summary}")
+                    print(f"   Ingestion FAILED: {status.error or status.content_summary}")
                     return
                 if elapsed > MAX_POLL_TIME:
                     print(f"   Timed out after {MAX_POLL_TIME}s")


### PR DESCRIPTION
## Summary
- Update `corpus_ingest.py` example to display `status.error` (the actual failure reason) instead of `status.content_summary` when ingestion fails

## Context
The `error` field on `ArtifactStatus` was always empty because upstream services (SM, Corpus) were dropping it. With MM-77/MM-78/MM-79 now propagating `error_msg` end-to-end, this field will contain meaningful failure reasons (e.g. "recovered: was parsing at restart").

The example now uses `status.error or status.content_summary` as a fallback chain.

One-line change — no new dependencies.