### PR TITLE
fix(models): coerce null list fields from API responses and fix set_a…

### DIFF
--- a/examples/persona_workflow.py
+++ b/examples/persona_workflow.py
@@ -83,7 +83,7 @@ async def main():
         # All list fields in GrowthConfig and DyadicConfig must be provided
         # explicitly (do not rely on defaults).
         # ==================================================================
-        print(f"\n--- Step 2: Create Version ---")
+        print("\n--- Step 2: Create Version ---")
 
         version = await client.v1.persona.create_version(
             persona_id=persona.id,
@@ -136,7 +136,7 @@ async def main():
         #
         # Returns the updated Persona object with active_version set.
         # ==================================================================
-        print(f"\n--- Step 3: Set Active Version ---")
+        print("\n--- Step 3: Set Active Version ---")
 
         updated_persona = await client.v1.persona.set_active_version(
             persona.id, version.id
@@ -159,7 +159,7 @@ async def main():
         #   Incorporates dyadic/relationship-specific context if dyadic
         #   is enabled on the active version.
         # ==================================================================
-        print(f"\n--- Step 4: Prepare System Prompt ---")
+        print("\n--- Step 4: Prepare System Prompt ---")
 
         # 4a. Global mode — no user context
         print("\n4a. Preparing (global mode)...")
@@ -198,7 +198,7 @@ async def main():
         # ==================================================================
         # ADDITIONAL: VERSION MANAGEMENT
         # ==================================================================
-        print(f"\n--- Additional: Version Management ---")
+        print("\n--- Additional: Version Management ---")
 
         # List all versions
         print("\nListing all versions...")
@@ -216,7 +216,7 @@ async def main():
         # ==================================================================
         # CLEANUP
         # ==================================================================
-        print(f"\n--- Cleanup ---")
+        print("\n--- Cleanup ---")
 
         await client.v1.persona.delete(persona.id)
         print(f"Deleted persona: {persona.id}")

--- a/examples/persona_workflow.py
+++ b/examples/persona_workflow.py
@@ -2,16 +2,16 @@
 Example: Persona Workflow
 
 Demonstrates the full persona lifecycle using the Magick Mind SDK:
-- Creating a persona with traits, tones, and a background story
-- Preparing a system prompt (global mode — no user context)
-- Preparing a per-user system prompt (dyadic/user-specific mode)
-- Version management: creating, listing, and activating versions
-- How prepared system prompts integrate with chat requests
 
-The `prepare` endpoint is the star of this example — it resolves a persona's
-traits, active version constraints, and optional user context into a
-ready-to-use system prompt string that can be injected directly into any
-LLM chat call.
+  1. Create a persona (name, role, traits, tones, background story)
+  2. Create a version (trait constraints, growth config, dyadic config)
+  3. Set the version as active
+  4. Prepare the system prompt (requires an active version)
+
+The flow is strictly sequential — you MUST have an active version before
+calling `prepare`. The prepare endpoint resolves the active version's trait
+constraints, growth rules, and optional user context into a system prompt
+string ready for any LLM chat call.
 """
 
 import asyncio
@@ -20,13 +20,19 @@ import os
 from dotenv import load_dotenv
 
 from magick_mind import MagickMind
-from magick_mind.models.v1.personality import TraitConstraint, TraitValue
+from magick_mind.models.v1.personality import (
+    Constraint,
+    DyadicConfig,
+    GrowthConfig,
+    TraitConstraint,
+    TraitValue,
+)
 
 load_dotenv()
 
 
 async def main():
-    """Demonstrate the persona creation, prepare, and versioning workflow."""
+    """Demonstrate the persona creation → versioning → prepare workflow."""
     base_url = os.getenv("MAGICKMIND_BASE_URL", "https://api.magickmind.ai")
     email = os.getenv("MAGICKMIND_EMAIL", "user@example.com")
     password = os.getenv("MAGICKMIND_PASSWORD", "your-password")
@@ -36,204 +42,184 @@ async def main():
         print("Persona Workflow Example")
         print("=" * 60)
 
-        # ====================================================================
-        # PART 1: CREATE & PREPARE (the core workflow)
-        # ====================================================================
-        print("\n" + "=" * 60)
-        print("PART 1: Create & Prepare")
-        print("=" * 60)
+        # ==================================================================
+        # STEP 1: CREATE PERSONA
+        # ==================================================================
+        # A persona defines the character's identity — name, role,
+        # descriptive traits, communication tones, and backstory.
+        # This does NOT make the persona usable yet; it needs a version.
+        # ==================================================================
+        print("\n--- Step 1: Create Persona ---")
 
-        # 1. Create a persona named "Aria"
-        print("\n1. Creating persona 'Aria'...")
         persona = await client.v1.persona.create(
             name="Aria",
             role="assistant",
             traits=["empathetic", "knowledgeable", "patient"],
             tones=["warm", "professional"],
             background_story=(
-                "Aria is a thoughtful AI assistant designed to help users navigate "
-                "complex topics with patience and clarity. She draws on broad knowledge "
-                "while maintaining a warm, approachable communication style."
+                "Aria is a thoughtful AI assistant designed to help users "
+                "navigate complex topics with patience and clarity. She draws "
+                "on broad knowledge while maintaining a warm, approachable "
+                "communication style."
             ),
         )
-        print(f"✓ Created persona: {persona.id}")
+        print(f"Created persona: {persona.id}")
         print(f"  Name:   {persona.name}")
         print(f"  Role:   {persona.role}")
         print(f"  Traits: {persona.traits}")
         print(f"  Tones:  {persona.tones}")
 
-        # 2. Prepare the persona — global mode (no user_id)
-        print(f"\n2. Preparing persona {persona.id} (global mode)...")
-        try:
-            global_prep = await client.v1.persona.prepare(persona.id)
-            print("✓ Global system prompt generated:")
-            print("-" * 40)
-            print(global_prep.system_prompt)
-            print("-" * 40)
-        except Exception as e:
-            print(f"✗ Prepare failed: {e}")
-            global_prep = None
+        # ==================================================================
+        # STEP 2: CREATE VERSION
+        # ==================================================================
+        # A version is a snapshot of the persona's trait constraints, growth
+        # configuration, and dyadic settings. You can create multiple
+        # versions, but only one can be active at a time.
+        #
+        # - constraints: pin traits to values or ranges with locks
+        # - growth: controls how traits evolve (FIXED = no change)
+        # - dyadic: controls per-user relationship adaptation
+        #
+        # All list fields in GrowthConfig and DyadicConfig must be provided
+        # explicitly (do not rely on defaults).
+        # ==================================================================
+        print(f"\n--- Step 2: Create Version ---")
 
-        # 3. Print the system_prompt (already printed above, summarise length)
-        if global_prep:
-            print(f"\n3. System prompt length: {len(global_prep.system_prompt)} chars")
-            print("   This prompt is ready to inject into any LLM chat request.")
-
-        # 4. Prepare with user_id — per-user / dyadic mode
-        print(f"\n4. Preparing persona {persona.id} with user_id='user-demo-001'...")
-        try:
-            user_prep = await client.v1.persona.prepare(
-                persona.id, user_id="user-demo-001"
-            )
-            print("✓ Per-user system prompt generated:")
-            print("-" * 40)
-            print(user_prep.system_prompt)
-            print("-" * 40)
-        except Exception as e:
-            print(f"✗ Per-user prepare failed: {e}")
-            user_prep = None
-
-        # 5. Note differences between global and per-user prompts
-        print("\n5. Comparing global vs per-user prompts:")
-        if global_prep and user_prep:
-            global_len = len(global_prep.system_prompt)
-            user_len = len(user_prep.system_prompt)
-            print(f"   Global prompt:   {global_len} chars")
-            print(f"   Per-user prompt: {user_len} chars")
-            if user_len != global_len:
-                print(
-                    "   → Per-user prompt differs: user context / dyadic memory "
-                    "has been incorporated."
-                )
-            else:
-                print(
-                    "   → Prompts are identical (no dyadic config set yet — "
-                    "see Part 2 for version-based customisation)."
-                )
-        else:
-            print("   (One or both prepare calls failed — skipping comparison)")
-
-        # ====================================================================
-        # PART 2: VERSION MANAGEMENT
-        # ====================================================================
-        print("\n" + "=" * 60)
-        print("PART 2: Version Management")
-        print("=" * 60)
-
-        # 6. Create version "1.1" with a trait constraint
-        print(f"\n6. Creating version '1.1' for persona {persona.id}...")
-        try:
-            version_1_1 = await client.v1.persona.create_version(
-                persona_id=persona.id,
-                version="1.1",
-                constraints=[
-                    TraitConstraint(
-                        trait_ref="empathetic",
-                        value=TraitValue(numeric_value=0.9),
+        version = await client.v1.persona.create_version(
+            persona_id=persona.id,
+            version="1.0.0",
+            constraints=[
+                TraitConstraint(
+                    trait_ref="empathetic",
+                    value=TraitValue(numeric_value=85.0),
+                    lock="HARD",
+                ),
+                TraitConstraint(
+                    trait_ref="patience",
+                    value=TraitValue(numeric_value=70.0),
+                    lock="SOFT",
+                    constraint=Constraint(
+                        min_bound=50.0,
+                        max_bound=90.0,
+                        learning_rate=0.1,
                     ),
-                ],
-            )
-            print(f"✓ Created version: {version_1_1.version}")
-            print(f"  Version ID:  {version_1_1.id}")
-            print(f"  Is active:   {version_1_1.is_active}")
-            print(f"  Constraints: {len(version_1_1.constraints)} constraint(s)")
-            for c in version_1_1.constraints:
-                val = c.value.numeric_value if c.value else None
-                print(f"    - {c.trait_ref}: numeric_value={val}")
-        except Exception as e:
-            print(f"✗ Create version failed: {e}")
-            version_1_1 = None
-
-        # 7. List all versions
-        print(f"\n7. Listing versions for persona {persona.id}...")
-        try:
-            versions_resp = await client.v1.persona.list_versions(persona.id)
-            print(f"✓ Found {len(versions_resp.data)} version(s):")
-            for v in versions_resp.data:
-                active_marker = " ← active" if v.is_active else ""
-                print(f"  - {v.version} (ID: {v.id}){active_marker}")
-        except Exception as e:
-            print(f"✗ List versions failed: {e}")
-
-        # 8. Set version "1.1" as active
-        if version_1_1:
-            print(f"\n8. Setting version '1.1' as active for persona {persona.id}...")
-            try:
-                activated = await client.v1.persona.set_active_version(
-                    persona.id, "1.1"
-                )
-                print(f"✓ Active version is now: {activated.version}")
-                print(f"  Is active: {activated.is_active}")
-            except Exception as e:
-                print(f"✗ Set active version failed: {e}")
-        else:
-            print("\n8. Skipping set_active_version (version creation failed)")
-
-        # 9. Prepare again — version constraints now affect the output
-        print(f"\n9. Preparing persona {persona.id} again (version 1.1 now active)...")
-        try:
-            versioned_prep = await client.v1.persona.prepare(persona.id)
-            print("✓ Versioned system prompt generated:")
-            print("-" * 40)
-            print(versioned_prep.system_prompt)
-            print("-" * 40)
-            print(
-                "   → The active version's trait constraints (empathetic=0.9) "
-                "are now reflected in the prompt."
-            )
-        except Exception as e:
-            print(f"✗ Versioned prepare failed: {e}")
-
-        # ====================================================================
-        # PART 3: USING PREPARE WITH CHAT (integration pattern)
-        # ====================================================================
-        print("\n" + "=" * 60)
-        print("PART 3: Using Prepare with Chat (Integration Pattern)")
-        print("=" * 60)
-
-        print("\n10. Integration pattern: prepare → inject system_prompt into chat")
-        print(
-            """
-   The `prepare` endpoint is designed to be called immediately before
-   starting (or resuming) a chat session. The returned `system_prompt`
-   is injected as the system message in your chat request:
-
-   ┌─────────────────────────────────────────────────────────────┐
-   │  # 1. Resolve the persona's system prompt                   │
-   │  prep = await client.v1.persona.prepare(                    │
-   │      persona_id,                                            │
-   │      user_id=current_user_id,   # optional, for dyadic      │
-   │  )                                                          │
-   │                                                             │
-   │  # 2. Send a chat message with the resolved system prompt   │
-   │  await client.v1.chat.send(                                 │
-   │      mindspace_id=mindspace_id,                             │
-   │      message="Hello, can you help me?",                     │
-   │      system_prompt=prep.system_prompt,                      │
-   │  )                                                          │
-   └─────────────────────────────────────────────────────────────┘
-
-   Key benefits:
-   • Trait constraints from the active version are automatically applied
-   • Per-user dyadic memory is incorporated when user_id is supplied
-   • The system prompt is always up-to-date with the latest version
-   • No manual prompt engineering required — the SDK handles assembly
-"""
+                ),
+            ],
+            growth=GrowthConfig(
+                type="FIXED",
+                domain_rates=None,
+                triggers=[],
+                goal_states=[],
+                boundaries=[],
+            ),
+            dyadic=DyadicConfig(
+                enabled=False,
+                max_relationships=0,
+                learnable_traits=[],
+                initial_weight=0.0,
+                max_weight=0.0,
+                confidence_threshold=0,
+            ),
         )
+        print(f"Created version: {version.version} (ID: {version.id})")
+        print(f"  Is active:   {version.is_active}")
+        print(f"  Constraints: {len(version.constraints)} constraint(s)")
+        for c in version.constraints:
+            val = c.value.numeric_value if c.value else None
+            print(f"    - {c.trait_ref}: {val} (lock={c.lock})")
 
-        # ====================================================================
+        # ==================================================================
+        # STEP 3: SET ACTIVE VERSION
+        # ==================================================================
+        # Activate the version so the prepare endpoint knows which trait
+        # configuration to resolve. Pass the version's ID (not the label).
+        #
+        # Returns the updated Persona object with active_version set.
+        # ==================================================================
+        print(f"\n--- Step 3: Set Active Version ---")
+
+        updated_persona = await client.v1.persona.set_active_version(
+            persona.id, version.id
+        )
+        print(f"Active version set: {updated_persona.active_version}")
+
+        # ==================================================================
+        # STEP 4: PREPARE THE SYSTEM PROMPT
+        # ==================================================================
+        # Now that an active version exists, the prepare endpoint resolves
+        # the persona's traits, active version constraints, and optional
+        # user context into a system prompt string.
+        #
+        # Without an active version, prepare will fail.
+        #
+        # Global mode (no user_id):
+        #   Returns a prompt based on the persona + active version only.
+        #
+        # Per-user mode (with user_id):
+        #   Incorporates dyadic/relationship-specific context if dyadic
+        #   is enabled on the active version.
+        # ==================================================================
+        print(f"\n--- Step 4: Prepare System Prompt ---")
+
+        # 4a. Global mode — no user context
+        print("\n4a. Preparing (global mode)...")
+        result = await client.v1.persona.prepare(persona.id)
+        print(f"System prompt ({len(result.system_prompt)} chars):")
+        print("-" * 40)
+        print(result.system_prompt)
+        print("-" * 40)
+
+        # 4b. Per-user mode — with user context
+        print("\n4b. Preparing (per-user mode, user_id='user-demo-001')...")
+        user_result = await client.v1.persona.prepare(
+            persona.id, user_id="user-demo-001"
+        )
+        print(f"Per-user system prompt ({len(user_result.system_prompt)} chars):")
+        print("-" * 40)
+        print(user_result.system_prompt)
+        print("-" * 40)
+
+        # ==================================================================
+        # INTEGRATION PATTERN: PREPARE → CHAT
+        # ==================================================================
+        # Call prepare before starting or resuming a chat session.
+        # Inject the returned system_prompt as the system message:
+        #
+        #   prep = await client.v1.persona.prepare(
+        #       persona_id, user_id=current_user_id
+        #   )
+        #   await client.v1.chat.send(
+        #       mindspace_id=mindspace_id,
+        #       message="Hello, can you help me?",
+        #       system_prompt=prep.system_prompt,
+        #   )
+        # ==================================================================
+
+        # ==================================================================
+        # ADDITIONAL: VERSION MANAGEMENT
+        # ==================================================================
+        print(f"\n--- Additional: Version Management ---")
+
+        # List all versions
+        print("\nListing all versions...")
+        versions_resp = await client.v1.persona.list_versions(persona.id)
+        print(f"Found {len(versions_resp.data)} version(s):")
+        for v in versions_resp.data:
+            marker = " <-- active" if v.is_active else ""
+            print(f"  - {v.version} (ID: {v.id}){marker}")
+
+        # Get the active version directly
+        print("\nGetting active version...")
+        active = await client.v1.persona.get_active_version(persona.id)
+        print(f"Active: {active.version} (ID: {active.id})")
+
+        # ==================================================================
         # CLEANUP
-        # ====================================================================
-        print("=" * 60)
-        print("CLEANUP")
-        print("=" * 60)
+        # ==================================================================
+        print(f"\n--- Cleanup ---")
 
-        print(f"\n1. Deleting persona {persona.id}...")
-        try:
-            await client.v1.persona.delete(persona.id)
-            print(f"✓ Deleted persona: {persona.id}")
-        except Exception as e:
-            print(f"✗ Failed to delete persona: {e}")
+        await client.v1.persona.delete(persona.id)
+        print(f"Deleted persona: {persona.id}")
 
         print("\n" + "=" * 60)
         print("Example completed successfully!")

--- a/magick_mind/models/errors.py
+++ b/magick_mind/models/errors.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ValidationErrorField(BaseModel):
@@ -59,6 +59,11 @@ class ProblemDetails(BaseModel):
     errors: list[ValidationErrorField] = Field(default_factory=list)
 
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="allow")
+
+    @field_validator("errors", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
 
 
 class ErrorResponse(BaseModel):

--- a/magick_mind/models/v1/blueprint.py
+++ b/magick_mind/models/v1/blueprint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from magick_mind.models.common import PageInfo
 from magick_mind.models.v1.personality import (
@@ -33,6 +33,11 @@ class Blueprint(BaseModel):
     created_by: str = ""
     created_at: str = ""
     updated_at: str = ""
+
+    @field_validator("traits", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
 
 
 class CreateBlueprintRequest(BaseModel):
@@ -110,6 +115,11 @@ class ValidateBlueprintResponse(BaseModel):
     valid: bool
     errors: list[ValidationError] = Field(default_factory=list)
 
+    @field_validator("errors", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
+
 
 class HydratedBlueprintTrait(BaseModel):
     """A blueprint trait enriched with full trait registry data."""
@@ -128,9 +138,19 @@ class HydratedBlueprint(BaseModel):
     blueprint: Blueprint
     hydrated_traits: list[HydratedBlueprintTrait] = Field(default_factory=list)
 
+    @field_validator("hydrated_traits", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
+
 
 class ListBlueprintsResponse(BaseModel):
     """Paginated list of blueprints."""
 
     data: list[Blueprint] = Field(default_factory=list)
     paging: PageInfo
+
+    @field_validator("data", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []

--- a/magick_mind/models/v1/corpus.py
+++ b/magick_mind/models/v1/corpus.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from magick_mind.models.common import PageInfo
 from magick_mind.models.v1.artifact import Artifact
@@ -100,6 +100,11 @@ class AddArtifactsResponse(BaseModel):
 
     added_count: int
     failed_artifact_ids: list[str] = Field(default_factory=list)
+
+    @field_validator("failed_artifact_ids", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
 
 
 class ArtifactStatus(BaseModel):

--- a/magick_mind/models/v1/mindspace.py
+++ b/magick_mind/models/v1/mindspace.py
@@ -121,6 +121,11 @@ class GetMindSpaceListResponse(BaseModel):
     )
     paging: PageInfo = Field(..., description="Pagination information")
 
+    @field_validator("data", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
+
     @property
     def mindspaces(self) -> list[MindSpace]:
         """Alias for data field (backward compatibility)."""
@@ -225,6 +230,11 @@ class ContextPrepareResponse(BaseModel):
     corpus: list[CorpusChunk] = Field(default_factory=list)
     fetcher: str = ""
 
+    @field_validator("chat_history", "corpus", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
+
 
 class LivekitTokenResponse(BaseModel):
     """Response containing a LiveKit access token."""
@@ -237,3 +247,8 @@ class LivekitJoinResponse(BaseModel):
     """Response from signalling agents to join LiveKit room."""
 
     signaled: list[str] = Field(default_factory=list)
+
+    @field_validator("signaled", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []

--- a/magick_mind/models/v1/persona.py
+++ b/magick_mind/models/v1/persona.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from magick_mind.models.common import PageInfo
 from magick_mind.models.v1.personality import (
@@ -27,6 +27,11 @@ class Persona(BaseModel):
     created_by: str = ""
     updated_by: str = ""
     active_version: Optional[str] = None
+
+    @field_validator("traits", "tones", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
 
 
 class CreatePersonaRequest(BaseModel):
@@ -79,6 +84,11 @@ class PersonaVersion(BaseModel):
     created_at: str = ""
     is_active: bool = False
 
+    @field_validator("constraints", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
+
 
 class CreatePersonaVersionRequest(BaseModel):
     """Request to create a new persona version."""
@@ -119,3 +129,8 @@ class ListPersonaVersionsResponse(BaseModel):
 
     data: list[PersonaVersion] = Field(default_factory=list)
     paging: PageInfo
+
+    @field_validator("data", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []

--- a/magick_mind/models/v1/personality.py
+++ b/magick_mind/models/v1/personality.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 # --- Enums ---
@@ -23,6 +23,11 @@ class TraitValue(BaseModel):
     string_value: Optional[str] = None
     string_list_value: list[str] = Field(default_factory=list)
 
+    @field_validator("string_list_value", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
+
 
 class Constraint(BaseModel):
     """Bounds and rules for a trait constraint."""
@@ -32,6 +37,11 @@ class Constraint(BaseModel):
     max_bound: Optional[float] = None
     allowed_values: list[str] = Field(default_factory=list)
     learning_rate: Optional[float] = None
+
+    @field_validator("allowed_values", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
 
 
 class TraitConstraint(BaseModel):
@@ -61,6 +71,11 @@ class GrowthTrigger(BaseModel):
     rate_multiplier: float
     direction: TriggerDirection
 
+    @field_validator("affected_traits", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
+
 
 class GoalState(BaseModel):
     """Target personality state with attraction dynamics."""
@@ -80,6 +95,11 @@ class Boundary(BaseModel):
     excluded_values: list[str] = Field(default_factory=list)
     reason: str
 
+    @field_validator("excluded_values", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
+
 
 class GrowthConfig(BaseModel):
     """Configuration for personality growth/evolution."""
@@ -89,6 +109,11 @@ class GrowthConfig(BaseModel):
     triggers: list[GrowthTrigger] = Field(default_factory=list)
     goal_states: list[GoalState] = Field(default_factory=list)
     boundaries: list[Boundary] = Field(default_factory=list)
+
+    @field_validator("triggers", "goal_states", "boundaries", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
 
 
 class DyadicConfig(BaseModel):
@@ -100,6 +125,11 @@ class DyadicConfig(BaseModel):
     initial_weight: float = 0.0
     max_weight: float = 0.0
     confidence_threshold: int = 0
+
+    @field_validator("learnable_traits", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []
 
 
 # --- Blueprint-specific ---

--- a/magick_mind/models/v1/runtime.py
+++ b/magick_mind/models/v1/runtime.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from magick_mind.models.v1.personality import LockType, TraitValue
 
@@ -35,3 +35,8 @@ class EffectivePersonality(BaseModel):
     traits: list[EffectiveTrait] = Field(default_factory=list)
     computed_at: str
     ttl_seconds: int
+
+    @field_validator("traits", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []

--- a/magick_mind/models/v1/trait.py
+++ b/magick_mind/models/v1/trait.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import ClassVar, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from magick_mind.models.common import PageInfo
 
@@ -125,3 +125,8 @@ class ListTraitsResponse(BaseModel):
 
     data: list[Trait] = Field(default_factory=list)
     paging: PageInfo
+
+    @field_validator("data", mode="before")
+    @classmethod
+    def _coerce_null_list(cls, v: object) -> object:
+        return v if v is not None else []

--- a/magick_mind/resources/v1/persona.py
+++ b/magick_mind/resources/v1/persona.py
@@ -323,20 +323,20 @@ class PersonaResourceV1(BaseResource):
         response = await self._http.get(Routes.persona_active_version(persona_id))
         return PersonaVersion.model_validate(response)
 
-    async def set_active_version(self, persona_id: str, version: str) -> PersonaVersion:
+    async def set_active_version(self, persona_id: str, version: str) -> Persona:
         """
         Set a version as active.
 
         Args:
             persona_id: Persona ID
-            version: Version string to activate
+            version: Version ID to activate
 
         Returns:
-            PersonaVersion
+            Persona with updated active_version
         """
         request = SetActiveVersionRequest(version=version)
         response = await self._http.put(
             Routes.persona_active_version(persona_id),
             json=request.model_dump(),
         )
-        return PersonaVersion.model_validate(response)
+        return Persona.model_validate(response)

--- a/tests/resources/test_persona.py
+++ b/tests/resources/test_persona.py
@@ -108,6 +108,12 @@ class TestPersonaResource:
             version="2.0",
             is_active=False,
         )
+        persona = PersonaFactory.build(
+            id="p-2",
+            name="Test",
+            role="assistant",
+            active_version="pv-2",
+        )
         mock_auth.add_response(
             url=f"{BASE_URL}/v1/persona/p-2/version",
             method="POST",
@@ -131,7 +137,7 @@ class TestPersonaResource:
         mock_auth.add_response(
             url=f"{BASE_URL}/v1/persona/p-2/version/active",
             method="PUT",
-            json=version.model_dump(mode="json"),
+            json=persona.model_dump(mode="json"),
         )
 
         created = await client.v1.persona.create_version(
@@ -149,7 +155,8 @@ class TestPersonaResource:
         assert active.id == "pv-2"
 
         set_active = await client.v1.persona.set_active_version("p-2", "2.0")
-        assert set_active.id == "pv-2"
+        assert set_active.id == "p-2"
+        assert set_active.active_version == "pv-2"
         body = json.loads(mock_auth.get_requests()[-1].content)
         assert body == {"version": "2.0"}
 


### PR DESCRIPTION
fix active_version return type

The Go backend serializes nil slices as null in JSON responses, but Pydantic's default_factory=list only handles missing fields, not explicit null. Added field_validator(mode=before) to coerce null to empty lists on all affected response models across the SDK.

Also fixed set_active_version to return Persona (not PersonaVersion) to match the actual API response, and updated the persona_workflow example to follow the correct sequential flow: create persona, create version, set active version, then prepare.