### PR TITLE
[ Refactor ] fix(persona): set active version via path param to match Bifrost API [ MM-224 ]

### DIFF
--- a/magick_mind/models/v1/__init__.py
+++ b/magick_mind/models/v1/__init__.py
@@ -94,7 +94,6 @@ from magick_mind.models.v1.persona import (
     PersonaWithVersion,
     PreparePersonaRequest,
     PreparePersonaResponse,
-    SetActiveVersionRequest,
     UpdatePersonaRequest,
 )
 from magick_mind.models.v1.personality import (
@@ -247,7 +246,6 @@ __all__ = [
     "CreatePersonaFromBlueprintRequest",
     "PersonaVersion",
     "CreatePersonaVersionRequest",
-    "SetActiveVersionRequest",
     "PersonaWithVersion",
     "PreparePersonaRequest",
     "PreparePersonaResponse",

--- a/magick_mind/models/v1/persona.py
+++ b/magick_mind/models/v1/persona.py
@@ -99,12 +99,6 @@ class CreatePersonaVersionRequest(BaseModel):
     dyadic: Optional[DyadicConfig] = None
 
 
-class SetActiveVersionRequest(BaseModel):
-    """Request to set the active version."""
-
-    version: str
-
-
 class PersonaWithVersion(BaseModel):
     """Response containing both persona and its initial version."""
 

--- a/magick_mind/resources/v1/persona.py
+++ b/magick_mind/resources/v1/persona.py
@@ -14,7 +14,6 @@ from magick_mind.models.v1.persona import (
     PersonaWithVersion,
     PreparePersonaRequest,
     PreparePersonaResponse,
-    SetActiveVersionRequest,
     UpdatePersonaRequest,
 )
 from magick_mind.models.v1.personality import (
@@ -334,9 +333,7 @@ class PersonaResourceV1(BaseResource):
         Returns:
             Persona with updated active_version
         """
-        request = SetActiveVersionRequest(version=version)
-        response = await self._http.put(
-            Routes.persona_active_version(persona_id),
-            json=request.model_dump(),
+        response = await self._http.post(
+            Routes.persona_activate_version(persona_id, version),
         )
         return Persona.model_validate(response)

--- a/magick_mind/routes.py
+++ b/magick_mind/routes.py
@@ -136,6 +136,11 @@ class Routes:
         """Get path for persona active version."""
         return f"/v1/persona/{persona_id}/version/active"
 
+    @staticmethod
+    def persona_activate_version(persona_id: str, version: str) -> str:
+        """Get path for activating a specific persona version."""
+        return f"/v1/persona/{persona_id}/version/{version}/activate"
+
     # Project endpoints
     PROJECTS = "/v1/projects"
 

--- a/tests/resources/test_persona.py
+++ b/tests/resources/test_persona.py
@@ -135,8 +135,8 @@ class TestPersonaResource:
             json=version.model_dump(mode="json"),
         )
         mock_auth.add_response(
-            url=f"{BASE_URL}/v1/persona/p-2/version/active",
-            method="PUT",
+            url=f"{BASE_URL}/v1/persona/p-2/version/2.0/activate",
+            method="POST",
             json=persona.model_dump(mode="json"),
         )
 
@@ -157,8 +157,9 @@ class TestPersonaResource:
         set_active = await client.v1.persona.set_active_version("p-2", "2.0")
         assert set_active.id == "p-2"
         assert set_active.active_version == "pv-2"
-        body = json.loads(mock_auth.get_requests()[-1].content)
-        assert body == {"version": "2.0"}
+        last_request = mock_auth.get_requests()[-1]
+        assert last_request.method == "POST"
+        assert last_request.url.path == "/v1/persona/p-2/version/2.0/activate"
 
     async def test_get_500_raises_problem_details(
         self, client: MagickMind, mock_auth: HTTPXMock


### PR DESCRIPTION
Bifrost changed the set-active-version endpoint to POST /v1/persona/{id}/version/{version}/activate (version as a path param, no body) instead of PUT .../version/active with a JSON body. Update the SDK to match: add the activate route, switch set_active_version() to POST with no body, drop the now-unused SetActiveVersionRequest model, and update tests.